### PR TITLE
Ensure UUID keys generated for inserts

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,6 +475,40 @@
             const itemsPerPage = 10;
             let currentData = [];
             let currentSection = '';
+            const uuidTables = new Set(['users', 'listings', 'bookings', 'user_reports', 'wallet_transactions', 'notifications']);
+            const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+            function generateUUID() {
+                if (typeof crypto !== 'undefined') {
+                    if (typeof crypto.randomUUID === 'function') {
+                        return crypto.randomUUID();
+                    }
+                    if (typeof crypto.getRandomValues === 'function') {
+                        const bytes = crypto.getRandomValues(new Uint8Array(16));
+                        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+                        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+                        const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
+                        return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+                    }
+                }
+                return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+                    const r = Math.random() * 16 | 0;
+                    const v = c === 'x' ? r : (r & 0x3 | 0x8);
+                    return v.toString(16);
+                });
+            }
+
+            function tableRequiresUuid(table) {
+                if (uuidTables.has(table)) {
+                    return true;
+                }
+                const sampleRow = currentData.find(row => row && row.id);
+                if (!sampleRow) {
+                    return false;
+                }
+                const sampleId = sampleRow.id;
+                return typeof sampleId === 'string' && uuidPattern.test(sampleId);
+            }
 
             function setActiveNav(section) {
                 console.log(`Setting active nav for section: ${section}`);
@@ -922,6 +956,9 @@
                         }
                         newItem[field] = value;
                     });
+                    if (!('id' in newItem) && tableRequiresUuid(table)) {
+                        newItem.id = generateUUID();
+                    }
                     const { error } = await supabase.from(table).insert([newItem]);
                     if (error) {
                         console.error(`Error adding to ${table}:`, error);


### PR DESCRIPTION
## Summary
- detect UUID-backed tables before inserting new records
- generate UUIDs with a crypto-based fallback when an ID is required

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d7cd950a5483229c23f9f902dae35e